### PR TITLE
skip ArrayPool<byte>.Shared.Return when buffer is null

### DIFF
--- a/src/MagicScaler/Magic/ConversionTransform.cs
+++ b/src/MagicScaler/Magic/ConversionTransform.cs
@@ -148,7 +148,10 @@ namespace PhotoSauce.MagicScaler.Transforms
 
 		public void Dispose()
 		{
-			ArrayPool<byte>.Shared.Return(lineBuff ?? Array.Empty<byte>());
+			if (lineBuff is null)
+				return;
+
+			ArrayPool<byte>.Shared.Return(lineBuff);
 			lineBuff = null;
 		}
 

--- a/src/MagicScaler/Magic/ConvolutionTransform.cs
+++ b/src/MagicScaler/Magic/ConvolutionTransform.cs
@@ -208,7 +208,10 @@ namespace PhotoSauce.MagicScaler.Transforms
 			SrcBuff?.Dispose();
 			WorkBuff?.Dispose();
 
-			ArrayPool<byte>.Shared.Return(lineBuff ?? Array.Empty<byte>());
+			if (lineBuff is null)
+				return;
+
+			ArrayPool<byte>.Shared.Return(lineBuff);
 			lineBuff = null;
 		}
 
@@ -261,7 +264,10 @@ namespace PhotoSauce.MagicScaler.Transforms
 		{
 			base.Dispose();
 
-			ArrayPool<byte>.Shared.Return(blurBuff ?? Array.Empty<byte>());
+			if (blurBuff is null)
+				return;
+
+			ArrayPool<byte>.Shared.Return(blurBuff);
 			blurBuff = null!;
 		}
 

--- a/src/MagicScaler/Magic/HybridScaleTransform.cs
+++ b/src/MagicScaler/Magic/HybridScaleTransform.cs
@@ -364,7 +364,11 @@ namespace PhotoSauce.MagicScaler.Transforms
 
 		public void Dispose()
 		{
-			ArrayPool<byte>.Shared.Return(lineBuff ?? Array.Empty<byte>());
+			if (lineBuff is null)
+				return;
+
+			ArrayPool<byte>.Shared.Return(lineBuff);
+
 			lineBuff = null!;
 		}
 

--- a/src/MagicScaler/Magic/KernelMap.cs
+++ b/src/MagicScaler/Magic/KernelMap.cs
@@ -224,7 +224,10 @@ namespace PhotoSauce.MagicScaler
 
 		public void Dispose()
 		{
-			ArrayPool<byte>.Shared.Return(map ?? Array.Empty<byte>());
+			if (map is null)
+				return;
+
+			ArrayPool<byte>.Shared.Return(map);
 			map = null!;
 		}
 	}

--- a/src/MagicScaler/Magic/OrientationTransform.cs
+++ b/src/MagicScaler/Magic/OrientationTransform.cs
@@ -246,7 +246,10 @@ namespace PhotoSauce.MagicScaler.Transforms
 		{
 			srcBuff?.Dispose();
 
-			ArrayPool<byte>.Shared.Return(lineBuff ?? Array.Empty<byte>());
+			if (lineBuff is null)
+				return;
+
+			ArrayPool<byte>.Shared.Return(lineBuff);
 			lineBuff = null;
 		}
 	}

--- a/src/MagicScaler/Magic/PlanarConversionTransform.cs
+++ b/src/MagicScaler/Magic/PlanarConversionTransform.cs
@@ -224,7 +224,10 @@ namespace PhotoSauce.MagicScaler.Transforms
 
 		public void Dispose()
 		{
-			ArrayPool<byte>.Shared.Return(lineBuff ?? Array.Empty<byte>());
+			if (lineBuff is null)
+				return;
+
+			ArrayPool<byte>.Shared.Return(lineBuff);
 			lineBuff = null!;
 		}
 	}


### PR DESCRIPTION
For stricter conformance with the ArrayPool Return method's documentation (specifying that the entry being returned to the pool be previously obtained usingRent(Int32)).