### PR TITLE
Align extension TFMs with main lib to prevent build feature mismatch.

### DIFF
--- a/src/NativeCodecs/Libheif/NativeCodecs.Libheif.csproj
+++ b/src/NativeCodecs/Libheif/NativeCodecs.Libheif.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<VersionPrefix>1.13.0</VersionPrefix>
-		<TargetFrameworks>net6.0;net472</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/NativeCodecs/Libjpeg/NativeCodecs.Libjpeg.csproj
+++ b/src/NativeCodecs/Libjpeg/NativeCodecs.Libjpeg.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<VersionPrefix>2.1.4</VersionPrefix>
-		<TargetFrameworks>net6.0;net472</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/NativeCodecs/Libjxl/NativeCodecs.Libjxl.csproj
+++ b/src/NativeCodecs/Libjxl/NativeCodecs.Libjxl.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<VersionPrefix>0.6.1</VersionPrefix>
-		<TargetFrameworks>net6.0;net472</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/NativeCodecs/Libpng/NativeCodecs.Libpng.csproj
+++ b/src/NativeCodecs/Libpng/NativeCodecs.Libpng.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<VersionPrefix>1.6.37</VersionPrefix>
-		<TargetFrameworks>net6.0;net472</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/NativeCodecs/Libwebp/NativeCodecs.Libwebp.csproj
+++ b/src/NativeCodecs/Libwebp/NativeCodecs.Libwebp.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<VersionPrefix>1.2.4</VersionPrefix>
-		<TargetFrameworks>net6.0;net472</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This fixes extensions (`libjxl`, `libpng` etc.) in `netcoreapp3.1` & `net5.0` runtimes. (I verified this manually inside dummy project).

Previously, when using these runtimes, a version of `libjxl` would be picked that doesn't natively support spans (`NS2.0`) and one that does for main library (`netcoreapp3.1`), leading to the extension trying to call stream extension method(s) that don't exist in the main library. [i.e. mismatched native span support define]

This PR simply changes the `.csproj` such that the extension TFMs match the main project's TFMs, under both default and `dist` configuration.