### PR TITLE
Make `IIccProfileSource` public

### DIFF
--- a/src/MagicScaler/Metadata/Metadata.cs
+++ b/src/MagicScaler/Metadata/Metadata.cs
@@ -32,9 +32,7 @@ internal readonly unsafe struct WicFrameMetadataReader : IMetadata
 	}
 }
 
-/// <summary>
-/// Provides a mechanism for accessing ICC color profile metadata.
-/// </summary>
+/// <summary>Provides a mechanism for accessing ICC color profile metadata.</summary>
 public interface IIccProfileSource : IMetadata
 {
 	int ProfileLength { get; }

--- a/src/MagicScaler/Metadata/Metadata.cs
+++ b/src/MagicScaler/Metadata/Metadata.cs
@@ -32,7 +32,10 @@ internal readonly unsafe struct WicFrameMetadataReader : IMetadata
 	}
 }
 
-internal interface IIccProfileSource : IMetadata
+/// <summary>
+/// Provides a mechanism for accessing ICC color profile metadata.
+/// </summary>
+public interface IIccProfileSource : IMetadata
 {
 	int ProfileLength { get; }
 	void CopyProfile(Span<byte> dest);


### PR DESCRIPTION
As per our discussion on Discord. This affords the ability to provide profile data to the processing pipeline.