### PR TITLE
add net8.0 target framework on Native Codecs project

### DIFF
--- a/src/NativeCodecs/Giflib/NativeCodecs.Giflib.csproj
+++ b/src/NativeCodecs/Giflib/NativeCodecs.Giflib.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<VersionPrefix>5.2.1</VersionPrefix>
-		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net472</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 

--- a/src/NativeCodecs/Libheif/NativeCodecs.Libheif.csproj
+++ b/src/NativeCodecs/Libheif/NativeCodecs.Libheif.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<VersionPrefix>1.17.5</VersionPrefix>
-		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net472</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 

--- a/src/NativeCodecs/Libjpeg/NativeCodecs.Libjpeg.csproj
+++ b/src/NativeCodecs/Libjpeg/NativeCodecs.Libjpeg.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<VersionPrefix>3.0.1</VersionPrefix>
-		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net472</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 

--- a/src/NativeCodecs/Libjxl/NativeCodecs.Libjxl.csproj
+++ b/src/NativeCodecs/Libjxl/NativeCodecs.Libjxl.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<VersionPrefix>0.8.2</VersionPrefix>
-		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net472</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 

--- a/src/NativeCodecs/Libpng/NativeCodecs.Libpng.csproj
+++ b/src/NativeCodecs/Libpng/NativeCodecs.Libpng.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<VersionPrefix>1.6.40</VersionPrefix>
-		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net472</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 

--- a/src/NativeCodecs/Libwebp/NativeCodecs.Libwebp.csproj
+++ b/src/NativeCodecs/Libwebp/NativeCodecs.Libwebp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<VersionPrefix>1.3.2</VersionPrefix>
-		<TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net472</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Configuration)'=='Dist' Or '$(Configuration)'=='Coverage'">$(TargetFrameworks);net461;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 


### PR DESCRIPTION
This PR enables the target net8.0 for the Native Codecs project.

After compiling the project locally, I added the reference and things started to work again.

Issue related: https://github.com/saucecontrol/PhotoSauce/issues/143

