### PR TITLE
Experimental `IPixelProcessor` and `TransformFactory.CreatePixelProcessor`

### DIFF
--- a/src/MagicScaler/Experimental/PixelProcessor.cs
+++ b/src/MagicScaler/Experimental/PixelProcessor.cs
@@ -1,0 +1,41 @@
+// Copyright © Clinton Ingram and Contributors
+// SPDX-License-Identifier: MIT
+
+using PhotoSauce.MagicScaler.Converters;
+
+using System;
+
+namespace PhotoSauce.MagicScaler.Experimental;
+
+/// <summary>Provides a mechanism for processing raw pixel data using caller-provided buffers.</summary>
+public interface IPixelProcessor
+{
+	/// <summary>Processes the pixels in <paramref name="source"/> and stores the results in <paramref name="dest"/>.</summary>
+	/// <param name="dest">A target memory buffer that will receive the pixel data.</param>
+	/// <param name="source">A source memory buffer that pixel data will be read from.</param>
+	void Process(Span<byte> dest, ReadOnlySpan<byte> source);
+}
+
+internal static class PixelProcessor
+{
+	public static IPixelProcessor FromConversionProcessor(IConversionProcessor processor)
+	{
+		return new ConversionProcessorWrapper(processor);
+	}
+
+	private sealed class ConversionProcessorWrapper(IConversionProcessor processor) : IPixelProcessor
+	{
+		private readonly IConversionProcessor processor = processor;
+
+		public unsafe void Process(Span<byte> dest, ReadOnlySpan<byte> source)
+		{
+			// TODO: argument validation? how to validate that dest has enough bytes for source?
+
+			fixed (byte* op = dest)
+			fixed (byte* ip = source)
+			{
+				processor.ConvertLine(ip, op, source.Length);
+			}
+		}
+	}
+}

--- a/src/MagicScaler/Experimental/PixelProcessor.cs
+++ b/src/MagicScaler/Experimental/PixelProcessor.cs
@@ -42,8 +42,8 @@ internal static class PixelProcessor
 
 			if (sourceFormat.BitsPerPixel == destFormat.BitsPerPixel)
 			{
-				// Converters that operate on same-sized elements assume that istart==ostart, e.g. the conversion is only done in-place.
-				// In order to avoid leaking that implementation detail, copy the input to output and then process output in-place.
+				// Converters that operate on same-sized elements assume that istart==ostart, e.g. the conversion is done in-place.
+				// In order to avoid leaking that implementation detail, copy input to output and then process output in-place.
 				if (istart != ostart)
 					Buffer.MemoryCopy(istart, ostart, cbo, cbi);
 				processor.ConvertLine(ostart, ostart, cbi);

--- a/src/MagicScaler/Experimental/PixelProcessor.cs
+++ b/src/MagicScaler/Experimental/PixelProcessor.cs
@@ -15,7 +15,7 @@ public interface IPixelProcessor
 	/// <param name="istart">A pointer to the input buffer.</param>
 	/// <param name="cbi">The size, in bytes, of the input buffer.</param>
 	/// <param name="ostart">A pointer to the output buffer.</param>
-	/// <param name="cbo">The size, in bytes, of the input buffer.</param>
+	/// <param name="cbo">The size, in bytes, of the output buffer.</param>
 	/// <exception cref="ArgumentException">Thrown when the output buffer is too small.</exception>
 	unsafe void Process(byte* istart, nint cbi, byte* ostart, nint cbo);
 }

--- a/src/MagicScaler/Experimental/PixelProcessor.cs
+++ b/src/MagicScaler/Experimental/PixelProcessor.cs
@@ -40,7 +40,16 @@ internal static class PixelProcessor
 			if (ocount < icount)
 				throw new ArgumentException($"Output buffer is too small");
 
-			processor.ConvertLine(istart, ostart, cbi);
+			if (sourceFormat.BitsPerPixel == destFormat.BitsPerPixel)
+			{
+				// Converters that operate on same-sized elements assume that istart==ostart, e.g. the conversion is only done in-place.
+				// In order to avoid leaking that implementation detail, copy the input to output and then process output in-place.
+				if (istart != ostart)
+					Buffer.MemoryCopy(istart, ostart, cbo, cbi);
+				processor.ConvertLine(ostart, ostart, cbi);
+			}
+			else
+				processor.ConvertLine(istart, ostart, cbi);
 		}
 	}
 }

--- a/src/MagicScaler/Experimental/TransformFactory.cs
+++ b/src/MagicScaler/Experimental/TransformFactory.cs
@@ -10,6 +10,15 @@ namespace PhotoSauce.MagicScaler.Experimental;
 /// <summary>Contains methods for creating <see cref="IPixelSource" /> transforms. These may be changed or removed in future releases.</summary>
 public static class TransformFactory
 {
+	/// <summary>Create a processor that converts raw pixel data to the given pixel format, optionally using the given ICC color profiles for gamma correction.</summary>
+	/// <param name="sourceFormat">The binary representation of the source pixel data.  Must be one of the values from <see cref="PixelFormats"/>.</param>
+	/// <param name="destFormat">The binary representation of the destination pixel data.  Must be one of the values from <see cref="PixelFormats"/>.</param>
+	/// <param name="sourceProfile">The ICC color profile to use for the source pixel data. If null, sRGB will be used.</param>
+	/// <param name="destProfile">The ICC color profile to use for the resulting pixel data. If null, sRGB will be used.</param>
+	/// <returns>An <see cref="IPixelProcessor"/> that can be used to process pixel data.</returns>
+	public static IPixelProcessor CreateConversionProcessor(Guid sourceFormat, Guid destFormat, IColorProfileHandle? sourceProfile = null, IColorProfileHandle? destProfile = null) =>
+		PixelProcessor.FromConversionProcessor(ConversionTransform.CreateProcessor(PixelFormat.FromGuid(sourceFormat), PixelFormat.FromGuid(destFormat), sourceProfile?.ColorProfile, destProfile?.ColorProfile));
+
 	/// <summary>Creates a transform that converts an <see cref="IPixelSource" /> to the given pixel format, optionally using the given ICC color profiles for gamma correction.</summary>
 	/// <param name="source">The <see cref="IPixelSource" /> to retrieve pixels from.</param>
 	/// <param name="destFormat">The binary representation of the resulting pixel data.  Must be one of the values from <see cref="PixelFormats" />.</param>

--- a/src/MagicScaler/Experimental/TransformFactory.cs
+++ b/src/MagicScaler/Experimental/TransformFactory.cs
@@ -16,8 +16,13 @@ public static class TransformFactory
 	/// <param name="sourceProfile">The ICC color profile to use for the source pixel data. If null, sRGB will be used.</param>
 	/// <param name="destProfile">The ICC color profile to use for the resulting pixel data. If null, sRGB will be used.</param>
 	/// <returns>An <see cref="IPixelProcessor"/> that can be used to process pixel data.</returns>
-	public static IPixelProcessor CreateConversionProcessor(Guid sourceFormat, Guid destFormat, IColorProfileHandle? sourceProfile = null, IColorProfileHandle? destProfile = null) =>
-		PixelProcessor.FromConversionProcessor(ConversionTransform.CreateProcessor(PixelFormat.FromGuid(sourceFormat), PixelFormat.FromGuid(destFormat), sourceProfile?.ColorProfile, destProfile?.ColorProfile));
+	[CLSCompliant(false)]
+	public static IPixelProcessor CreateConversionProcessor(Guid sourceFormat, Guid destFormat, IColorProfileHandle? sourceProfile = null, IColorProfileHandle? destProfile = null)
+	{
+		PixelFormat sourcePixelFormat = PixelFormat.FromGuid(sourceFormat);
+		PixelFormat destPixelFormat = PixelFormat.FromGuid(destFormat);
+		return PixelProcessor.FromConversionProcessor(ConversionTransform.CreateProcessor(sourcePixelFormat, destPixelFormat, sourceProfile?.ColorProfile, destProfile?.ColorProfile), sourcePixelFormat, destPixelFormat);
+	}
 
 	/// <summary>Creates a transform that converts an <see cref="IPixelSource" /> to the given pixel format, optionally using the given ICC color profiles for gamma correction.</summary>
 	/// <param name="source">The <see cref="IPixelSource" /> to retrieve pixels from.</param>

--- a/src/MagicScaler/Utilities/MathUtil.cs
+++ b/src/MagicScaler/Utilities/MathUtil.cs
@@ -135,6 +135,9 @@ internal static class MathUtil
 	public static int DivCeiling(int x, int y) => (int)(((uint)x + ((uint)y - 1)) / (uint)y);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static nint DivCeiling(nint x, nint y) => (nint)(((nuint)x + ((nuint)y - 1)) / (nuint)y);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static int PowerOfTwoFloor(int x, int powerOfTwo) => x & ~(powerOfTwo - 1);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
In reference to our discussion on Discord: https://discord.com/channels/143867839282020352/960223751599976479/1357748411335573779

This provides me the ability to do conversion transforms without locking them into a specific `IPixelSource`. I can then reuse the processor on my side for my own processing pipelines, especially in cases where it would be slow or burdensome to do otherwise.

Not quite sure how/if to do parameter validation in `PixelProcessor.ConversionProcessorWrapper.Process()`.